### PR TITLE
Improve topic normalization and fallback logic

### DIFF
--- a/src/hooks/useSupabaseData.tsx
+++ b/src/hooks/useSupabaseData.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { normalizeTopic } from "@/utils/normalizeTopic";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
@@ -139,7 +140,7 @@ export const useSupabaseData = () => {
       // Validate and transform data
       const validatedSources = (data || []).map(source => {
         // Safely cast enum values to proper types
-        const difficulty_level = (['beginner', 'intermediate', 'advanced'] as const).includes(source.difficulty_level as any) 
+        const difficulty_level = (['beginner', 'intermediate', 'advanced'] as const).includes(source.difficulty_level as any)
           ? source.difficulty_level as 'beginner' | 'intermediate' | 'advanced'
           : 'beginner';
         
@@ -153,6 +154,8 @@ export const useSupabaseData = () => {
 
         return {
           ...source,
+          category: normalizeTopic(source.category),
+          subcategory: source.subcategory ? normalizeTopic(source.subcategory) : undefined,
           difficulty_level,
           source_type,
           language_preference,

--- a/src/utils/normalizeTopic.ts
+++ b/src/utils/normalizeTopic.ts
@@ -1,15 +1,31 @@
 export const topicAliases: Record<string, string> = {
   'daily practice': 'daily_practice',
   'daily-practice': 'daily_practice',
+  'halakhah': 'halacha',
+  'halachah': 'halacha',
+  'halakha': 'halacha',
+  'halachic': 'halacha',
   'hilchot deot': 'hilchot_deot',
   'hilchot-deot': 'hilchot_deot',
   'hilchot teshuva': 'hilchot_teshuva',
   'hilchot-teshuva': 'hilchot_teshuva',
+  'maimonides': 'rambam',
   'weekly portion': 'weekly_portion',
   'weekly-portion': 'weekly_portion',
   'pirkei avot': 'pirkei_avot',
   'short sugyot': 'short_sugyot',
-  'jewish thought': 'jewish_philosophy'
+  'jewish thought': 'jewish_philosophy',
+  'tanach': 'tanakh',
+  'bible': 'tanakh',
+  'gemara': 'talmud',
+  'mishna': 'talmud',
+  'mishnah': 'talmud',
+  'spirituality': 'spiritual',
+  'chasidus': 'chassidut',
+  'chassidus': 'chassidut',
+  'musar': 'mussar',
+  'kabalah': 'spiritual',
+  'kabbalah': 'spiritual'
 };
 
 export const normalizeTopic = (topic: string): string => {


### PR DESCRIPTION
## Summary
- normalize category and subcategory fields when loading from Supabase
- extend alias map used by `normalizeTopic`
- loosen topic matching comparisons and add related-topic fallback in recommendation hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6889ee78f3f88326875deb54ba455951