### PR TITLE
Fix category mismatch for parasha

### DIFF
--- a/src/utils/normalizeTopic.ts
+++ b/src/utils/normalizeTopic.ts
@@ -7,9 +7,11 @@ export const topicAliases: Record<string, string> = {
   'hilchot-teshuva': 'hilchot_teshuva',
   'weekly portion': 'weekly_portion',
   'weekly-portion': 'weekly_portion',
-  'parasha': 'weekly_portion',
-  'parsha': 'weekly_portion',
-  'parashat_hashavua': 'weekly_portion',
+  // Treat various parasha spellings as the Tanakh category
+  // since weekly portions are stored under Tanakh in the database
+  'parasha': 'tanakh',
+  'parsha': 'tanakh',
+  'parashat_hashavua': 'tanakh',
   'pirkei avot': 'pirkei_avot',
   'short sugyot': 'short_sugyot',
   'jewish thought': 'jewish_philosophy',

--- a/supabase/migrations/20250728135000-merge-parasha-category.sql
+++ b/supabase/migrations/20250728135000-merge-parasha-category.sql
@@ -1,0 +1,5 @@
+-- Merge parasha category into tanakh and ensure subcategory is weekly_portion
+UPDATE public.sources
+SET category = 'tanakh',
+    subcategory = COALESCE(subcategory, 'weekly_portion')
+WHERE category = 'parasha';


### PR DESCRIPTION
## Summary
- handle `parasha` as part of the `tanakh` category in code
- add migration to update existing sources with category `parasha`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6889f8da8510832699cf511ca6999fa3