### PR TITLE
Implement topic standardization and API key docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,12 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 
 ## Environment Variables
 
-Some features rely on external services. To enable AI source generation you must
-set an `AIzaSyCMS2jvyLPwMmdVuR360XNXwar4wz2P5kY'
-
-` environment variable in your Supabase function or local
-environment. Without this key the `ai-source-generator` function will fail.
+Some features rely on external services. To enable AI source generation you need
+ to provide an `OPENAI_API_KEY` environment variable in your Supabase function or local environment. Without this key the `ai-source-generator` function will fail.
 
 Example `.env` entry:
 
 ```bash
-AIzaSyCMS2jvyLPwMmdVuR360XNXwar4wz2P5kY
-=your-openai-api-key
+OPENAI_API_KEY=your-openai-api-key
 ```
 

--- a/src/hooks/useSmartRecommendation.tsx
+++ b/src/hooks/useSmartRecommendation.tsx
@@ -73,8 +73,13 @@ export const useSmartRecommendation = (
     
     // Primary filter: exact topic match + optimal time + type compatibility + quality validation
     const primaryFilter = sources.filter(source => {
-      const matchesTopic = normalizeTopic(source.category) === normalizedTopic ||
-                          normalizeTopic(source.subcategory || '') === normalizedTopic;
+      const categorySlug = normalizeTopic(source.category);
+      const subSlug = normalizeTopic(source.subcategory || '');
+      const matchesTopic =
+        categorySlug === normalizedTopic ||
+        subSlug === normalizedTopic ||
+        categorySlug.includes(normalizedTopic) ||
+        subSlug.includes(normalizedTopic);
       const timeMatch = config.timeSelected >= (source.min_time || source.estimated_time - 5) && 
                        config.timeSelected <= (source.max_time || source.estimated_time + 5);
       const typeMatch = !timeFilter.types.length || timeFilter.types.includes(source.source_type || 'text_study');
@@ -100,8 +105,13 @@ export const useSmartRecommendation = (
 
     // Secondary filter: expand time range but keep topic match
     const secondaryFilter = sources.filter(source => {
-      const matchesTopic = normalizeTopic(source.category) === normalizedTopic ||
-                          normalizeTopic(source.subcategory || '') === normalizedTopic;
+      const categorySlug = normalizeTopic(source.category);
+      const subSlug = normalizeTopic(source.subcategory || '');
+      const matchesTopic =
+        categorySlug === normalizedTopic ||
+        subSlug === normalizedTopic ||
+        categorySlug.includes(normalizedTopic) ||
+        subSlug.includes(normalizedTopic);
       const timeMatch = config.timeSelected >= (source.min_time || source.estimated_time - 10) && 
                        config.timeSelected <= (source.max_time || source.estimated_time + 15);
       const notInHistory = !sourceHistory.includes(source.id);

--- a/src/utils/normalizeTopic.ts
+++ b/src/utils/normalizeTopic.ts
@@ -13,13 +13,28 @@ export const topicAliases: Record<string, string> = {
   'parsha': 'tanakh',
   'parashat_hashavua': 'tanakh',
   'pirkei avot': 'pirkei_avot',
+  'pirkei_avos': 'pirkei_avot',
+  'pirkei avos': 'pirkei_avot',
   'short sugyot': 'short_sugyot',
   'jewish thought': 'jewish_philosophy',
   'tanach': 'tanakh',
-  'chasidut': 'chassidut'
+  'chasidut': 'chassidut',
+  'mixed topics': 'mixed',
+  'mixed-topics': 'mixed',
+  'musar': 'mussar',
+  'shabbos': 'shabbat',
+  'hilchot_deos': 'hilchot_deot',
+  'hilchos_deos': 'hilchot_deot'
 };
 
 export const normalizeTopic = (topic: string): string => {
-  const slug = topic.toLowerCase().replace(/[\s-]+/g, '_').trim();
+  const slug = topic
+    .toLowerCase()
+    .replace(/[’'"`]/g, '')
+    .replace(/[&]/g, 'and')
+    .replace(/[.,:!?]/g, '')
+    .replace(/[\s-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .trim();
   return topicAliases[slug] || slug;
 };

--- a/supabase/migrations/20250728135100-standardize-subcategories.sql
+++ b/supabase/migrations/20250728135100-standardize-subcategories.sql
@@ -1,0 +1,21 @@
+-- Ensure subcategories use lowercase with underscores and fix known cases
+UPDATE public.sources
+SET subcategory = lower(replace(subcategory, ' ', '_'))
+WHERE subcategory IS NOT NULL AND (subcategory ~ '[A-Z]' OR subcategory LIKE '% %');
+
+UPDATE public.sources SET subcategory = 'daily_practice'
+  WHERE subcategory IN ('Daily Practice', 'dailyPractice', 'daily_practice');
+UPDATE public.sources SET subcategory = 'hilchot_deot'
+  WHERE subcategory IN ('Hilchot Deot', 'hilchotDeot', 'Hilchot_Deot');
+UPDATE public.sources SET subcategory = 'hilchot_teshuva'
+  WHERE subcategory IN ('Hilchot Teshuva', 'hilchotTeshuva', 'Hilchot_Teshuva');
+UPDATE public.sources SET subcategory = 'pirkei_avot'
+  WHERE subcategory IN ('Pirkei Avot', 'pirkeiAvot', 'Pirkei_Avot');
+UPDATE public.sources SET subcategory = 'weekly_portion'
+  WHERE subcategory IN ('Weekly Portion', 'weeklyPortion', 'Weekly_Portion');
+UPDATE public.sources SET subcategory = 'mixed'
+  WHERE subcategory IN ('Mixed Topics', 'mixedTopics', 'Mixed_Topics');
+UPDATE public.sources SET subcategory = 'mussar'
+  WHERE subcategory IN ('Mussar');
+UPDATE public.sources SET subcategory = 'shabbat'
+  WHERE subcategory IN ('Shabbat');


### PR DESCRIPTION
## Summary
- document proper `OPENAI_API_KEY` usage in README
- expand topic normalization to handle more aliases and punctuation
- relax topic matching logic in smart recommendations
- add migration for subcategory normalization

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6889fb1679808326800fc5b1a03d2f77