### PR TITLE
Enable strict flags in tsconfig

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,11 +15,12 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitAny": false,
-    "noFallthroughCasesInSwitch": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
 
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- enable strict mode for app tsconfig

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npx tsc --noEmit -p tsconfig.app.json` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_6886139d64d88326ad3129dd3a41ee0e