### PR TITLE
Fix topic matching and fallback logic

### DIFF
--- a/src/hooks/useSmartRecommendation.tsx
+++ b/src/hooks/useSmartRecommendation.tsx
@@ -98,6 +98,10 @@ export const useSmartRecommendation = (
              source.published && languageMatch && qualityCheck;
     });
 
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('primaryFilter', primaryFilter.length);
+    }
+
     // Return primary if we have good matches
     if (primaryFilter.length > 0) {
       return primaryFilter;
@@ -121,6 +125,10 @@ export const useSmartRecommendation = (
       return matchesTopic && timeMatch && notInHistory && source.published && languageMatch;
     });
 
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('secondaryFilter', secondaryFilter.length);
+    }
+
     if (secondaryFilter.length > 0) {
       return secondaryFilter;
     }
@@ -138,6 +146,10 @@ export const useSmartRecommendation = (
       
       return matchesRelated && timeMatch && notInHistory && source.published && languageMatch;
     });
+
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('tertiaryFilter', tertiaryFilter.length);
+    }
 
     if (tertiaryFilter.length > 0) {
       return tertiaryFilter;
@@ -158,9 +170,15 @@ export const useSmartRecommendation = (
         relatedSet.has(normalizeTopic(s.subcategory || ''))
       );
 
-    const pool = prioritized.length > 0 ? prioritized : allSources;
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('quaternary candidates', prioritized.length);
+    }
 
-    return pool.sort((a, b) => {
+    if (prioritized.length === 0) {
+      return [];
+    }
+
+    return prioritized.sort((a, b) => {
       const aTimeDiff = Math.abs(a.estimated_time - config.timeSelected);
       const bTimeDiff = Math.abs(b.estimated_time - config.timeSelected);
       return aTimeDiff - bTimeDiff;

--- a/src/utils/normalizeTopic.ts
+++ b/src/utils/normalizeTopic.ts
@@ -22,6 +22,7 @@ export const topicAliases: Record<string, string> = {
   'mixed topics': 'mixed',
   'mixed-topics': 'mixed',
   'musar': 'mussar',
+  'chasidus': 'chassidut',
   'shabbos': 'shabbat',
   'hilchot_deos': 'hilchot_deot',
   'hilchos_deos': 'hilchot_deot'

--- a/supabase/migrations/20250728135500-more-topic-normalization.sql
+++ b/supabase/migrations/20250728135500-more-topic-normalization.sql
@@ -1,0 +1,11 @@
+-- Additional normalization for category and subcategory values
+UPDATE public.sources SET category = lower(replace(category, ' ', '_'))
+  WHERE category ~ '[A-Z]' OR category LIKE '% %';
+UPDATE public.sources SET subcategory = lower(replace(subcategory, ' ', '_'))
+  WHERE subcategory IS NOT NULL AND (subcategory ~ '[A-Z]' OR subcategory LIKE '% %');
+
+-- Handle remaining known variations
+UPDATE public.sources SET category = 'spiritual'
+  WHERE category IN ('musar', 'mussar');
+UPDATE public.sources SET subcategory = 'chassidut'
+  WHERE subcategory IN ('chasidut', 'chasidus');


### PR DESCRIPTION
## Summary
- map more topic aliases like `chasidus`
- add debug logging and tighten fallback in `useSmartRecommendation`
- add migration to normalize categories/subcategories further

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6889fd4b1b848326a9421525bb290c8f