### PR TITLE
Add quality indicators for sources

### DIFF
--- a/src/components/EnhancedSourceDisplay.tsx
+++ b/src/components/EnhancedSourceDisplay.tsx
@@ -1,8 +1,11 @@
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
 import { Source } from "@/hooks/useSupabaseData";
+import { useContentQualityAssurance } from "@/hooks/useContentQualityAssurance";
 import { Language } from "./LanguageToggle";
+import { useEffect, useState } from "react";
 import { 
   ExternalLink, 
   MapPin, 
@@ -42,6 +45,8 @@ const content = {
     philosophical: "Philosophical",
     historical: "Historical",
     mystical: "Mystical"
+    ,
+    qualityScore: "Quality Score"
   },
   he: {
     torahReference: "מקור תורני",
@@ -65,17 +70,32 @@ const content = {
     philosophical: "פילוסופי",
     historical: "היסטורי",
     mystical: "מיסטי"
+    ,
+    qualityScore: "מדד איכות"
   }
 };
 
-export const EnhancedSourceDisplay = ({ 
-  source, 
-  language, 
-  onSefariaClick 
+export const EnhancedSourceDisplay = ({
+  source,
+  language,
+  onSefariaClick
 }: EnhancedSourceDisplayProps) => {
   const t = content[language];
   const title = language === 'he' ? source.title_he : source.title;
   const textExcerpt = language === 'he' ? source.text_excerpt_he : source.text_excerpt;
+
+  const { assessSourceQuality } = useContentQualityAssurance();
+  const [qualityScore, setQualityScore] = useState<number | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    assessSourceQuality(source).then(metrics => {
+      if (mounted) setQualityScore(metrics.score);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [source, assessSourceQuality]);
 
   const getDifficultyColor = (difficulty?: string) => {
     switch (difficulty) {
@@ -115,6 +135,17 @@ export const EnhancedSourceDisplay = ({
               <Badge variant="secondary" className="bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-300">
                 AI
               </Badge>
+            )}
+            {qualityScore !== null && (
+              <div className="flex items-center gap-1 ml-auto">
+                <span className="text-xs font-medium">
+                  {t.qualityScore}
+                </span>
+                <Progress value={qualityScore} className="w-20 h-2" />
+                <span className="text-xs text-muted-foreground">
+                  {Math.round(qualityScore)}%
+                </span>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- display a quality score using `useContentQualityAssurance`
- show a small progress bar with the calculated score

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6889fe5b6e788326b1a3deeafedf6778