### PR TITLE
Add source data checks and slug constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "validate:sources": "node scripts/validateSources.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/validateSources.mjs
+++ b/scripts/validateSources.mjs
@@ -1,0 +1,59 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(url, key, {
+  auth: { persistSession: false }
+});
+
+(async () => {
+  const { data, error } = await supabase
+    .from('sources')
+    .select('*');
+
+  if (error) {
+    console.error('Error fetching sources:', error.message);
+    process.exit(1);
+  }
+
+  const issues = [];
+  const slugPattern = /^[a-z_]+$/;
+
+  for (const source of data) {
+    const missing = [];
+    if (!source.title) missing.push('title');
+    if (!source.title_he) missing.push('title_he');
+    if (!source.category) missing.push('category');
+    if (!source.start_ref) missing.push('start_ref');
+    if (!source.end_ref) missing.push('end_ref');
+    if (!source.sefaria_link) missing.push('sefaria_link');
+    if (!source.reflection_prompt) missing.push('reflection_prompt');
+    if (!source.reflection_prompt_he) missing.push('reflection_prompt_he');
+
+    if (missing.length) {
+      issues.push({ id: source.id, missing });
+    }
+
+    if (source.category && !slugPattern.test(source.category)) {
+      issues.push({ id: source.id, invalidCategory: source.category });
+    }
+
+    if (source.subcategory && !slugPattern.test(source.subcategory)) {
+      issues.push({ id: source.id, invalidSubcategory: source.subcategory });
+    }
+  }
+
+  if (issues.length) {
+    console.table(issues);
+    console.error(`Found ${issues.length} sources with issues`);
+    process.exitCode = 1;
+  } else {
+    console.log('All sources look good!');
+  }
+})();

--- a/supabase/migrations/20250728140010-add-source-format-constraints.sql
+++ b/supabase/migrations/20250728140010-add-source-format-constraints.sql
@@ -1,0 +1,16 @@
+-- Enforce lowercase slug format for categories and subcategories
+ALTER TABLE public.sources
+  ADD CONSTRAINT category_slug CHECK (category ~ '^[a-z_]+$');
+
+ALTER TABLE public.sources
+  ADD CONSTRAINT subcategory_slug CHECK (subcategory IS NULL OR subcategory ~ '^[a-z_]+$');
+
+-- Ensure key fields are present
+ALTER TABLE public.sources
+  ALTER COLUMN title SET NOT NULL,
+  ALTER COLUMN title_he SET NOT NULL,
+  ALTER COLUMN category SET NOT NULL,
+  ALTER COLUMN start_ref SET NOT NULL,
+  ALTER COLUMN end_ref SET NOT NULL,
+  ALTER COLUMN reflection_prompt SET NOT NULL,
+  ALTER COLUMN reflection_prompt_he SET NOT NULL;


### PR DESCRIPTION
## Summary
- provide script `validateSources.mjs` to flag missing fields and incorrect slugs
- enforce lowercase slug format and NOT NULL constraints on the `sources` table via migration
- expose a `validate:sources` npm script

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6889ff72323c83268e40de9e9e6861d7