### PR TITLE
Improve mobile nav and loading feedback

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Home, BookOpen, Settings, BarChart3, Search, Sparkles } from "lucide-react";
 
 interface BottomNavProps {
+  currentStep: string;
   onHome: () => void;
   onJournal: () => void;
   onProfile: () => void;
@@ -10,32 +11,62 @@ interface BottomNavProps {
   onAdmin?: () => void;
 }
 
-export const BottomNav = ({ onHome, onJournal, onProfile, onAnalytics, onSearch, onAdmin }: BottomNavProps) => {
+export const BottomNav = ({ currentStep, onHome, onJournal, onProfile, onAnalytics, onSearch, onAdmin }: BottomNavProps) => {
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-background border-t border-border shadow-soft md:hidden">
       <div className="flex justify-around py-2">
-        <Button variant="ghost" size="icon" aria-label="Home" onClick={onHome}>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Home"
+          onClick={onHome}
+          className={`h-11 w-11 ${currentStep === 'welcome' ? 'text-primary' : ''}`}
+        >
           <Home className="h-5 w-5" />
         </Button>
-        <Button variant="ghost" size="icon" aria-label="Journal" onClick={onJournal}>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Journal"
+          onClick={onJournal}
+          className={`h-11 w-11 ${currentStep === 'journal' ? 'text-primary' : ''}`}
+        >
           <BookOpen className="h-5 w-5" />
         </Button>
         {onAnalytics && (
-          <Button variant="ghost" size="icon" aria-label="Analytics" onClick={onAnalytics}>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Analytics"
+            onClick={onAnalytics}
+            className={`h-11 w-11 ${currentStep === 'analytics' ? 'text-primary' : ''}`}
+          >
             <BarChart3 className="h-5 w-5" />
           </Button>
         )}
         {onSearch && (
-          <Button variant="ghost" size="icon" aria-label="Search" onClick={onSearch}>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Search"
+            onClick={onSearch}
+            className={`h-11 w-11 ${currentStep === 'search' ? 'text-primary' : ''}`}
+          >
             <Search className="h-5 w-5" />
           </Button>
         )}
         {onAdmin && (
-          <Button variant="ghost" size="icon" aria-label="Admin" onClick={onAdmin}>
+          <Button variant="ghost" size="icon" aria-label="Admin" onClick={onAdmin} className="h-11 w-11">
             <Sparkles className="h-5 w-5" />
           </Button>
         )}
-        <Button variant="ghost" size="icon" aria-label="Profile" onClick={onProfile}>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Profile"
+          onClick={onProfile}
+          className={`h-11 w-11 ${currentStep === 'profile' ? 'text-primary' : ''}`}
+        >
           <Settings className="h-5 w-5" />
         </Button>
       </div>

--- a/src/components/OrayataApp.tsx
+++ b/src/components/OrayataApp.tsx
@@ -12,7 +12,7 @@ import { AdvancedSearchAndDiscovery } from "./AdvancedSearchAndDiscovery";
 import { NavigationHeader } from "./NavigationHeader";
 import { OfflineIndicator } from "./OfflineIndicator";
 import { BottomNav } from "./BottomNav";
-import { LoadingSpinner } from "./LoadingSpinner";
+import { SourceLoadingState } from "./SourceLoadingState";
 import { useAppContext } from "@/context/AppContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useUserProfile } from "@/hooks/useUserProfile";
@@ -23,13 +23,9 @@ export const OrayataApp = () => {
   const { state, actions } = useAppContext();
   const { currentStep, language, selectedTime, selectedTopic, currentSource } = state;
 
-  // Show loading spinner while checking authentication
+  // Show skeleton while checking authentication
   if (authLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <LoadingSpinner size="lg" />
-      </div>
-    );
+    return <SourceLoadingState variant="minimal" />;
   }
 
   // Load persisted settings on mount
@@ -186,6 +182,7 @@ export const OrayataApp = () => {
 
       {/* Bottom Navigation - always visible */}
       <BottomNav
+        currentStep={currentStep}
         onHome={() => actions.setStep('welcome')}
         onJournal={handleJournal}
         onProfile={handleOpenProfile}

--- a/src/index.css
+++ b/src/index.css
@@ -133,6 +133,11 @@
     font-variant-numeric: oldstyle-nums;
   }
 
+  html {
+    font-size: clamp(14px, 0.9vw + 14px, 18px);
+    line-height: 1.5;
+  }
+
   /* Hebrew Typography */
   .hebrew {
     @apply font-alef;


### PR DESCRIPTION
## Summary
- add active state styling and larger touch targets to BottomNav
- show skeleton state during authentication check
- enable fluid base typography using clamp()

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688a026b99288326a2b0b0585cbf31cb