### PR TITLE
refactor: streamline auth and profile hooks

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -36,7 +36,10 @@ export default function Auth() {
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
-    const { } = await signUp(email, password, name);
+    const { error } = await signUp(email, password, name);
+    if (!error) {
+      navigate("/");
+    }
     setIsLoading(false);
   };
 

--- a/supabase/functions/gemini-source-agent/index.ts
+++ b/supabase/functions/gemini-source-agent/index.ts
@@ -14,7 +14,7 @@ interface GenerationRequest {
   userContext?: {
     name?: string;
     learningHistory?: string[];
-    preferences?: any;
+    preferences?: Record<string, unknown>;
     difficulty?: string;
   };
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -125,5 +126,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- handle signup errors and redirect after successful registration
- tighten user profile types and hook logic
- reuse parsed webhook responses and import tailwind plugin cleanly

## Testing
- `npx eslint src/pages/Auth.tsx src/hooks/useUserProfile.tsx src/hooks/useWebhookSource.tsx tailwind.config.ts supabase/functions/gemini-source-agent/index.ts`
- `npm run lint` *(fails: unexpected any in useSmartRecommendation.tsx, useSupabaseData.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_b_68934d6e9b508326bfd673a1542ac0a6