### PR TITLE
feat: add global theme and language toggles

### DIFF
--- a/src/components/OrayataApp.tsx
+++ b/src/components/OrayataApp.tsx
@@ -13,6 +13,8 @@ import { NavigationHeader } from "./NavigationHeader";
 import { OfflineIndicator } from "./OfflineIndicator";
 import { BottomNav } from "./BottomNav";
 import { SourceLoadingState } from "./SourceLoadingState";
+import { LanguageToggle } from "./LanguageToggle";
+import { DarkModeToggle } from "./DarkModeToggle";
 import { useAppContext } from "@/context/AppContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useUserProfile } from "@/hooks/useUserProfile";
@@ -94,9 +96,16 @@ export const OrayataApp = () => {
 
   // Apply RTL direction to the entire app when Hebrew is selected
   const appDirection = selectedLanguage === 'he' ? 'rtl' : 'ltr';
+  const isHebrew = selectedLanguage === 'he';
 
   return (
     <div dir={appDirection} className="font-inter min-h-screen bg-background">
+      {/* Global toggles */}
+      <div className={`fixed top-4 z-50 flex items-center gap-2 ${isHebrew ? 'left-4' : 'right-4'}`}>
+        <LanguageToggle language={selectedLanguage} onLanguageChange={actions.setLanguage} />
+        <DarkModeToggle />
+      </div>
+
       {/* Show navigation header for learning flow */}
       {['time', 'topic', 'source', 'reflection'].includes(currentStep) && (
         <NavigationHeader />
@@ -106,7 +115,6 @@ export const OrayataApp = () => {
         {currentStep === 'welcome' && (
             <WelcomeScreen
               language={selectedLanguage}
-              onLanguageChange={actions.setLanguage}
               onStartLearning={handleStartLearning}
               onJournal={handleJournal}
               onProfile={handleOpenProfile}

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,11 +1,9 @@
 import { Button } from "@/components/ui/button";
-import { LanguageToggle, Language } from "./LanguageToggle";
-import { DarkModeToggle } from "./DarkModeToggle";
+import { type Language } from "./LanguageToggle";
 import { BookOpen, Clock, Heart } from "lucide-react";
 
 interface WelcomeScreenProps {
   language: Language;
-  onLanguageChange: (lang: Language) => void;
   onStartLearning: () => void;
   onJournal: () => void;
   onProfile: () => void;
@@ -52,23 +50,17 @@ const content = {
   }
 };
 
-export const WelcomeScreen = ({ language, onLanguageChange, onStartLearning, onJournal, onProfile, onAnalytics, onSearch }: WelcomeScreenProps) => {
+export const WelcomeScreen = ({ language, onStartLearning, onJournal, onProfile, onAnalytics, onSearch }: WelcomeScreenProps) => {
   const t = content[language];
   const isHebrew = language === 'he';
 
   return (
     <div className={`min-h-screen bg-gradient-subtle flex items-center justify-center mobile-container safe-bottom ${isHebrew ? 'hebrew' : ''}`}>
       <div className="w-full max-w-2xl text-center mobile-spacing-y animate-fade-in">
-        {/* Header with Language Toggle - Mobile Optimized */}
-        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
-          <div className="text-center sm:text-left">
-            <div className="text-base sm:text-sm text-muted-foreground font-medium px-4 sm:px-0">
-              {t.greeting}
-            </div>
-          </div>
-          <div className="flex items-center gap-2 justify-center sm:justify-end">
-            <LanguageToggle language={language} onLanguageChange={onLanguageChange} />
-            <DarkModeToggle />
+        {/* Header */}
+        <div className="mb-6">
+          <div className="text-base sm:text-sm text-muted-foreground font-medium px-4 sm:px-0">
+            {t.greeting}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add persistent language and dark mode toggles to main app container so they're visible on every page
- streamline welcome screen header now that global toggles exist

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: see errors)*

------
https://chatgpt.com/codex/tasks/task_b_68983ee3e7548326aad920c8ee38f032