### PR TITLE
feat: add mobile drawer for global toggles

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,5 +1,14 @@
 import { Button } from "@/components/ui/button";
-import { Home, BookOpen, Settings, BarChart3, Search, Sparkles } from "lucide-react";
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Home, BookOpen, Settings, BarChart3, Search, Sparkles, User } from "lucide-react";
+import { LanguageToggle, type Language } from "./LanguageToggle";
+import { DarkModeToggle } from "./DarkModeToggle";
 
 interface BottomNavProps {
   currentStep: string;
@@ -9,13 +18,26 @@ interface BottomNavProps {
   onAnalytics?: () => void;
   onSearch?: () => void;
   onAdmin?: () => void;
+  language: Language;
+  onLanguageChange: (lang: Language) => void;
 }
 
-export const BottomNav = ({ currentStep, onHome, onJournal, onProfile, onAnalytics, onSearch, onAdmin }: BottomNavProps) => {
+export const BottomNav = ({
+  currentStep,
+  onHome,
+  onJournal,
+  onProfile,
+  onAnalytics,
+  onSearch,
+  onAdmin,
+  language,
+  onLanguageChange,
+}: BottomNavProps) => {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-background/98 backdrop-blur-lg border-t border-border shadow-soft md:hidden z-50">
-      <div className="safe-area-inset-bottom">
-        <div className="flex justify-around py-3 px-2">
+    <Drawer>
+      <nav className="fixed bottom-0 left-0 right-0 bg-background/98 backdrop-blur-lg border-t border-border shadow-soft md:hidden z-50">
+        <div className="safe-area-inset-bottom">
+          <div className="flex justify-around py-3 px-2">
           <Button
             variant="ghost"
             size="icon"
@@ -77,11 +99,11 @@ export const BottomNav = ({ currentStep, onHome, onJournal, onProfile, onAnalyti
             </Button>
           )}
           {onAdmin && (
-            <Button 
-              variant="ghost" 
-              size="icon" 
-              aria-label="Admin" 
-              onClick={onAdmin} 
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Admin"
+              onClick={onAdmin}
               className="h-14 w-16 flex flex-col gap-1 rounded-xl touch-button transition-all duration-200 hover:bg-muted/50"
             >
               <Sparkles className="h-5 w-5" />
@@ -94,16 +116,36 @@ export const BottomNav = ({ currentStep, onHome, onJournal, onProfile, onAnalyti
             aria-label="Profile"
             onClick={onProfile}
             className={`h-14 w-16 flex flex-col gap-1 rounded-xl touch-button transition-all duration-200 ${
-              currentStep === 'profile' 
-                ? 'text-primary bg-primary/15 shadow-lg scale-105' 
+              currentStep === 'profile'
+                ? 'text-primary bg-primary/15 shadow-lg scale-105'
                 : 'hover:bg-muted/50'
             }`}
           >
-            <Settings className="h-5 w-5" />
+            <User className="h-5 w-5" />
             <span className="text-xs font-medium">Profile</span>
           </Button>
+          <DrawerTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Preferences"
+              className="h-14 w-16 flex flex-col gap-1 rounded-xl touch-button transition-all duration-200 hover:bg-muted/50"
+            >
+              <Settings className="h-5 w-5" />
+              <span className="text-xs font-medium">Prefs</span>
+            </Button>
+          </DrawerTrigger>
         </div>
-      </div>
-    </nav>
+      </nav>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Preferences</DrawerTitle>
+        </DrawerHeader>
+        <div className="p-4 flex flex-col gap-4">
+          <LanguageToggle language={language} onLanguageChange={onLanguageChange} />
+          <DarkModeToggle />
+        </div>
+      </DrawerContent>
+    </Drawer>
   );
 };

--- a/src/components/OrayataApp.tsx
+++ b/src/components/OrayataApp.tsx
@@ -13,6 +13,8 @@ import { NavigationHeader } from "./NavigationHeader";
 import { OfflineIndicator } from "./OfflineIndicator";
 import { BottomNav } from "./BottomNav";
 import { SourceLoadingState } from "./SourceLoadingState";
+import { LanguageToggle } from "./LanguageToggle";
+import { DarkModeToggle } from "./DarkModeToggle";
 import { useAppContext } from "@/context/AppContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useUserProfile } from "@/hooks/useUserProfile";
@@ -94,9 +96,23 @@ export const OrayataApp = () => {
 
   // Apply RTL direction to the entire app when Hebrew is selected
   const appDirection = selectedLanguage === 'he' ? 'rtl' : 'ltr';
+  const isHebrew = selectedLanguage === 'he';
 
   return (
     <div dir={appDirection} className="font-inter min-h-screen bg-background">
+      {/* Global toggles - desktop only */}
+      <div
+        className={`fixed top-4 z-50 hidden md:flex items-center gap-2 ${
+          isHebrew ? 'left-4' : 'right-4'
+        }`}
+      >
+        <LanguageToggle
+          language={selectedLanguage}
+          onLanguageChange={actions.setLanguage}
+        />
+        <DarkModeToggle />
+      </div>
+
       {/* Show navigation header for learning flow */}
       {['time', 'topic', 'source', 'reflection'].includes(currentStep) && (
         <NavigationHeader />
@@ -106,7 +122,6 @@ export const OrayataApp = () => {
         {currentStep === 'welcome' && (
             <WelcomeScreen
               language={selectedLanguage}
-              onLanguageChange={actions.setLanguage}
               onStartLearning={handleStartLearning}
               onJournal={handleJournal}
               onProfile={handleOpenProfile}
@@ -193,6 +208,8 @@ export const OrayataApp = () => {
         onAnalytics={handleAnalytics}
         onSearch={handleSearch}
         onAdmin={profile?.role === 'admin' ? handleAdmin : undefined}
+        language={selectedLanguage}
+        onLanguageChange={actions.setLanguage}
       />
 
       {/* Offline Support */}

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,11 +1,9 @@
 import { Button } from "@/components/ui/button";
-import { LanguageToggle, Language } from "./LanguageToggle";
-import { DarkModeToggle } from "./DarkModeToggle";
+import { type Language } from "./LanguageToggle";
 import { BookOpen, Clock, Heart } from "lucide-react";
 
 interface WelcomeScreenProps {
   language: Language;
-  onLanguageChange: (lang: Language) => void;
   onStartLearning: () => void;
   onJournal: () => void;
   onProfile: () => void;
@@ -52,23 +50,17 @@ const content = {
   }
 };
 
-export const WelcomeScreen = ({ language, onLanguageChange, onStartLearning, onJournal, onProfile, onAnalytics, onSearch }: WelcomeScreenProps) => {
+export const WelcomeScreen = ({ language, onStartLearning, onJournal, onProfile, onAnalytics, onSearch }: WelcomeScreenProps) => {
   const t = content[language];
   const isHebrew = language === 'he';
 
   return (
     <div className={`min-h-screen bg-gradient-subtle flex items-center justify-center mobile-container safe-bottom ${isHebrew ? 'hebrew' : ''}`}>
       <div className="w-full max-w-2xl text-center mobile-spacing-y animate-fade-in">
-        {/* Header with Language Toggle - Mobile Optimized */}
-        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
-          <div className="text-center sm:text-left">
-            <div className="text-base sm:text-sm text-muted-foreground font-medium px-4 sm:px-0">
-              {t.greeting}
-            </div>
-          </div>
-          <div className="flex items-center gap-2 justify-center sm:justify-end">
-            <LanguageToggle language={language} onLanguageChange={onLanguageChange} />
-            <DarkModeToggle />
+        {/* Header */}
+        <div className="mb-6">
+          <div className="text-base sm:text-sm text-muted-foreground font-medium px-4 sm:px-0">
+            {t.greeting}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- hide theme and language toggles on small screens
- add settings drawer in bottom nav with language and dark mode controls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 70 problems (41 errors, 29 warnings))*

------
https://chatgpt.com/codex/tasks/task_b_68983ee3e7548326aad920c8ee38f032