### PR TITLE
refactor: tighten test and streak typings

### DIFF
--- a/src/components/LearningStats.tsx
+++ b/src/components/LearningStats.tsx
@@ -188,16 +188,20 @@ export function LearningStats({ language }: LearningStatsProps) {
   );
 }
 
-function calculateStreak(sessions: any[]): number {
+interface Session {
+  createdAt: Date;
+}
+
+function calculateStreak(sessions: Session[]): number {
   if (sessions.length === 0) return 0;
-  
+
   // Sort sessions by date (newest first)
-  const sortedSessions = [...sessions].sort((a, b) => 
-    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  const sortedSessions = [...sessions].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   );
-  
+
   let streak = 0;
-  let currentDate = new Date();
+  const currentDate = new Date();
   currentDate.setHours(0, 0, 0, 0);
   
   // Check each day going backwards

--- a/src/utils/commentarySelector.test.ts
+++ b/src/utils/commentarySelector.test.ts
@@ -133,12 +133,33 @@ export const testCases = [
 ];
 
 /**
+ * Structure of a single test result.
+ */
+interface TestResult {
+  name: string;
+  passed: boolean;
+  expected: {
+    shouldProvide: boolean;
+    commentaries: string[];
+  };
+  actual: {
+    shouldProvide: boolean;
+    commentaries: string[];
+    sourceType: string;
+  };
+}
+
+/**
  * Run all tests and return results
  */
-export function runCommentaryTests(): { passed: number; failed: number; results: any[] } {
+export function runCommentaryTests(): {
+  passed: number;
+  failed: number;
+  results: TestResult[];
+} {
   let passed = 0;
   let failed = 0;
-  const results = [];
+  const results: TestResult[] = [];
 
   for (const testCase of testCases) {
     const result = debugSourceTypeIdentification(testCase.config);


### PR DESCRIPTION
## Summary
- define TestResult interface for commentary tests
- type learning sessions and use const for current date

## Testing
- `npm run lint` (fails: 79 problems, 50 errors)
- `bun test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68998c4d0a4483268d6f04adb9252ded