### PR TITLE
Use environment variable for webhook URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_WEBHOOK_URL=https://hook.eu2.make.com/replace-with-your-webhook

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/src/hooks/useWebhookSource.tsx
+++ b/src/hooks/useWebhookSource.tsx
@@ -239,7 +239,11 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
     setError(null);
 
     try {
-      const response = await fetch('https://hook.eu2.make.com/yph8frq3ykdvsqjjbz0zxym2ihrjnv1j', {
+      const webhookUrl = import.meta.env.VITE_WEBHOOK_URL;
+      if (!webhookUrl) {
+        throw new Error('Webhook URL is not configured');
+      }
+      const response = await fetch(webhookUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_WEBHOOK_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,6 +7,9 @@ schemas = ["public", "graphql_public"]
 extra_search_path = ["public", "extensions"]
 max_rows = 1000
 
+[functions.env]
+  VITE_WEBHOOK_URL = "https://hook.eu2.make.com/replace-with-your-webhook"
+
 [functions.ai-source-generator]
 verify_jwt = false
 


### PR DESCRIPTION
## Summary
- Replace hardcoded Make webhook URL with `import.meta.env.VITE_WEBHOOK_URL`
- Document webhook URL in `.env.example`
- Supply webhook URL via Supabase config and add `.env` to `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 82 problems)*

------
https://chatgpt.com/codex/tasks/task_b_689990bc75088326a99f5aae003cf448