### PR TITLE
test: add sefaria link validator tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "validate:sources": "node scripts/validateSources.mjs"
+    "validate:sources": "node scripts/validateSources.mjs",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -83,6 +84,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/utils/sefariaLinkValidator.test.ts
+++ b/src/utils/sefariaLinkValidator.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { isValidSefariaUrl, normalizeSefariaUrl, extractTextReference } from './sefariaLinkValidator';
+
+describe('isValidSefariaUrl', () => {
+  it('accepts sefaria.org URLs', () => {
+    expect(isValidSefariaUrl('https://www.sefaria.org/Genesis.1')).toBe(true);
+  });
+
+  it('accepts sefaria.org.il URLs', () => {
+    expect(isValidSefariaUrl('https://www.sefaria.org.il/Genesis.1')).toBe(true);
+  });
+
+  it('rejects non-Sefaria URLs', () => {
+    expect(isValidSefariaUrl('https://example.com/Genesis.1')).toBe(false);
+  });
+});
+
+describe('normalizeSefariaUrl', () => {
+  it('converts .org.il to canonical .org', () => {
+    const input = 'https://www.sefaria.org.il/Genesis.1?lang=he';
+    const output = 'https://www.sefaria.org/Genesis.1?lang=he';
+    expect(normalizeSefariaUrl(input)).toBe(output);
+  });
+
+  it('leaves canonical .org URLs unchanged', () => {
+    const url = 'https://www.sefaria.org/Genesis.1';
+    expect(normalizeSefariaUrl(url)).toBe(url);
+  });
+
+  it('throws on invalid URLs', () => {
+    expect(() => normalizeSefariaUrl('https://example.com')).toThrowError('Invalid Sefaria URL');
+  });
+});
+
+describe('extractTextReference', () => {
+  it('extracts reference from canonical URLs', () => {
+    const url = 'https://www.sefaria.org/Genesis.1.1-3?lang=he';
+    expect(extractTextReference(url)).toBe('Genesis.1.1-3');
+  });
+
+  it('normalizes .org.il URLs before extracting', () => {
+    const url = 'https://www.sefaria.org.il/Genesis.1.1-3?lang=en';
+    expect(extractTextReference(url)).toBe('Genesis.1.1-3');
+  });
+
+  it('returns null when no text reference is present', () => {
+    const url = 'https://www.sefaria.org/?lang=en';
+    expect(extractTextReference(url)).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Vitest unit tests for Sefaria URL utilities
- add `npm test` script and Vitest dev dependency

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: 55 errors, 29 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6899aca1eb208326ac7e724c285f9538