### PR TITLE
test: verify webhook source range parsing

### DIFF
--- a/src/hooks/__tests__/useWebhookSource.test.tsx
+++ b/src/hooks/__tests__/useWebhookSource.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('react', () => ({
+  useState: (initial: any) => [initial, () => {}],
+  useEffect: () => {},
+  useCallback: (fn: any) => fn,
+}));
+
+import { useWebhookSource } from '../useWebhookSource';
+
+describe('parseWebhookResponse', () => {
+  it('uses the exact source range provided in the webhook payload', () => {
+    const { parseWebhookResponse } = useWebhookSource(5, 'topic', 'en');
+
+    const sampleResponse = `
+English: Sample Title
+**Source Range**: Genesis 1:1-2
+
+**Brief Excerpt**: In the beginning...
+**Reflection Prompt**: What does this teach us?
+**Estimated Time**: 5
+**Sefaria**: https://www.sefaria.org/Genesis.1.1-5
+`;
+
+    const parsed = parseWebhookResponse(sampleResponse, 'en');
+    expect(parsed.source_range).toBe('Genesis 1:1-2');
+  });
+});

--- a/src/hooks/useWebhookSource.tsx
+++ b/src/hooks/useWebhookSource.tsx
@@ -313,6 +313,7 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
     source,
     loading,
     error,
-    refetch: fetchWebhookSource
+    refetch: fetchWebhookSource,
+    parseWebhookResponse
   };
 };


### PR DESCRIPTION
## Summary
- expose webhook parser from `useWebhookSource` for testing
- add unit test validating `parseWebhookResponse` preserves provided source range

## Testing
- `npx vitest run src/hooks/__tests__/useWebhookSource.test.tsx`
- `npm test` *(fails: commentarySelector tests)*

------
https://chatgpt.com/codex/tasks/task_b_6899c4d1e8448326974714a4fe48825f