### PR TITLE
Simplify source range parsing for webhook sources

### DIFF
--- a/src/hooks/useWebhookSource.tsx
+++ b/src/hooks/useWebhookSource.tsx
@@ -152,40 +152,28 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
       ? (rangeHebMatch?.[1] || rangeEngMatch?.[1])
       : (rangeEngMatch?.[1] || rangeHebMatch?.[1]))?.trim() || '';
 
-    // Clean and sanitize the source range
+    // Clean and sanitize the source range into a single line
     if (sourceRange) {
       sourceRange = sourceRange
-        // Remove any markdown formatting
         .replace(/\*+/g, '')
         .replace(/_+/g, '')
         .replace(/`+/g, '')
-        // Clean up excess whitespace but preserve line breaks for multi-line ranges
         .replace(/[ \t]+/g, ' ')
-        .replace(/\n+/g, '\n')
+        .replace(/\r?\n+/g, ' ')
         .trim();
     }
 
-    // Prefer explicit From/To if provided by webhook
+    // Use explicit From/To only if Source Range block is missing
     const fromPref = preferredLang === 'he' ? (fromHeb || fromEng) : (fromEng || fromHeb);
     const toPref = preferredLang === 'he' ? (toHeb || toEng) : (toEng || toHeb);
 
     let finalRange = sourceRange;
-    if (fromPref && toPref) {
-      finalRange = `${fromPref} ${preferredLang === 'he' ? 'עד' : 'to'} ${toPref}`.trim();
+    if (!finalRange && fromPref && toPref) {
+      finalRange = `${fromPref} ${preferredLang === 'he' ? 'עד' : '–'} ${toPref}`;
     }
 
-    // Fallback: derive range from Sefaria link if still missing
-    if (!finalRange && extractedLink) {
-      const m = extractedLink.match(/sefaria\.org\/([^?\#]+)/);
-      if (m?.[1]) {
-        let ref = decodeURIComponent(m[1])
-          .replace(/^texts\//i, '')
-          .replace(/_/g, ' ')
-          .trim();
-        // Only main ref segment
-        ref = ref.split(/[?\#]/)[0];
-        finalRange = ref;
-      }
+    if (finalRange) {
+      finalRange = finalRange.replace(/\s+/g, ' ').trim();
     }
     // Compute title with fallback to finalRange when explicit title missing (handles Hebrew)
     const baseTitle = (englishTitleRaw || hebrewTitleRaw || '').replace(/\*/g, '').trim();


### PR DESCRIPTION
## Summary
- Rely on Source Range block as primary range value
- Build range from From/To lines when Source Range block is absent
- Remove Sefaria link fallback and normalize whitespace for display

## Testing
- `npm test` *(fails: commentarySelector tests)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6899c4cda8088326b8808c0713f678f6