### PR TITLE
Preserve webhook source range formatting

### DIFF
--- a/src/hooks/__tests__/useWebhookSource.test.tsx
+++ b/src/hooks/__tests__/useWebhookSource.test.tsx
@@ -15,6 +15,8 @@ describe('parseWebhookResponse', () => {
     const sampleResponse = `
 English: Sample Title
 **Source Range**: Genesis 1:1-2
+From: Genesis 1:1
+To: Genesis 1:2
 
 **Brief Excerpt**: In the beginning...
 **Reflection Prompt**: What does this teach us?
@@ -23,6 +25,7 @@ English: Sample Title
 `;
 
     const parsed = parseWebhookResponse(sampleResponse, 'en');
+    // Even with explicit From/To lines present, the original Source Range should be preserved
     expect(parsed.source_range).toBe('Genesis 1:1-2');
   });
 });

--- a/src/hooks/useWebhookSource.tsx
+++ b/src/hooks/useWebhookSource.tsx
@@ -159,6 +159,10 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
         .replace(/\*+/g, '')
         .replace(/_+/g, '')
         .replace(/`+/g, '')
+        // Remove any explicit From/To lines accidentally captured in the range block
+        .split('\n')
+        .filter(line => !/^\s*(?:From|To|מ|עד)\s*[:：\-–—]?/i.test(line))
+        .join('\n')
         // Clean up excess whitespace but preserve line breaks for multi-line ranges
         .replace(/[ \t]+/g, ' ')
         .replace(/\n+/g, '\n')
@@ -170,7 +174,8 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
     const toPref = preferredLang === 'he' ? (toHeb || toEng) : (toEng || toHeb);
 
     let finalRange = sourceRange;
-    if (fromPref && toPref) {
+    // Only build a range from "From"/"To" lines when an explicit Source Range isn't provided
+    if (!finalRange && fromPref && toPref) {
       finalRange = `${fromPref} ${preferredLang === 'he' ? 'עד' : 'to'} ${toPref}`.trim();
     }
 


### PR DESCRIPTION
## Summary
- Clean source range text from webhook and drop stray From/To lines
- Only build range from From/To markers when Source Range missing
- Add unit test ensuring explicit Source Range is preserved

## Testing
- `npm test src/hooks/__tests__/useWebhookSource.test.tsx`
- `npm test` *(fails: commentarySelector tests)*

------
https://chatgpt.com/codex/tasks/task_b_6899c8f53ed08326aacf94d68bfaaef0