### PR TITLE
Fix Select.Item usage with non-empty values

### DIFF
--- a/src/components/AdminStatsDashboard.tsx
+++ b/src/components/AdminStatsDashboard.tsx
@@ -183,14 +183,16 @@ export const AdminStatsDashboard = () => {
             <div className="space-y-2">
               <Label htmlFor="topic">Topic</Label>
               <Select
-                value={filters.topic || ''}
-                onValueChange={(value) => setFilters({ ...filters, topic: value || undefined })}
+                value={filters.topic ?? 'all'}
+                onValueChange={(value) =>
+                  setFilters({ ...filters, topic: value === 'all' ? undefined : value })
+                }
               >
                 <SelectTrigger>
                   <SelectValue placeholder="All topics" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All topics</SelectItem>
+                  <SelectItem value="all">All topics</SelectItem>
                   {TOPICS.map((topic) => (
                     <SelectItem key={topic} value={topic}>
                       {topic}
@@ -203,14 +205,19 @@ export const AdminStatsDashboard = () => {
             <div className="space-y-2">
               <Label htmlFor="time_bucket">Time Bucket</Label>
               <Select
-                value={filters.time_bucket || ''}
-                onValueChange={(value) => setFilters({ ...filters, time_bucket: value || undefined })}
+                value={filters.time_bucket ?? 'all'}
+                onValueChange={(value) =>
+                  setFilters({
+                    ...filters,
+                    time_bucket: value === 'all' ? undefined : value,
+                  })
+                }
               >
                 <SelectTrigger>
                   <SelectValue placeholder="All durations" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All durations</SelectItem>
+                  <SelectItem value="all">All durations</SelectItem>
                   {TIME_BUCKETS.map((bucket) => (
                     <SelectItem key={bucket} value={bucket}>
                       {bucket} minutes

--- a/src/components/AdvancedSearch.tsx
+++ b/src/components/AdvancedSearch.tsx
@@ -15,7 +15,7 @@ interface AdvancedSearchProps {
 
 export const AdvancedSearch = ({ sources, onFilteredResults, language }: AdvancedSearchProps) => {
   const [query, setQuery] = useState("");
-  const [category, setCategory] = useState("");
+  const [category, setCategory] = useState("all");
   const [showFilters, setShowFilters] = useState(false);
 
   const filteredSources = useMemo(() => {
@@ -30,7 +30,7 @@ export const AdvancedSearch = ({ sources, onFilteredResults, language }: Advance
       });
     }
 
-    if (category) {
+    if (category !== 'all') {
       filtered = filtered.filter(source => source.category === category);
     }
 
@@ -68,7 +68,7 @@ export const AdvancedSearch = ({ sources, onFilteredResults, language }: Advance
             <SelectValue placeholder="All Categories" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">All Categories</SelectItem>
+            <SelectItem value="all">All Categories</SelectItem>
             <SelectItem value="halacha">Halacha</SelectItem>
             <SelectItem value="rambam">Rambam</SelectItem>
             <SelectItem value="tanakh">Tanakh</SelectItem>


### PR DESCRIPTION
## Summary
- Replace empty string values in admin filters with explicit `all` option
- Update advanced search category filter to use `all` sentinel instead of empty string

## Testing
- `npm test` (fails: expected true to be false)
- `npm run lint` (fails: @typescript-eslint/no-explicit-any)


------
https://chatgpt.com/codex/tasks/task_b_6899cfb0f64c8326aeaf24e8d788ed54