### PR TITLE
Add safe defaults for admin analytics

### DIFF
--- a/src/components/AdminAnalyticsDashboard.tsx
+++ b/src/components/AdminAnalyticsDashboard.tsx
@@ -28,6 +28,24 @@ interface AnalyticsData {
   deviceSplit: { ios: number; android: number; web: number };
 }
 
+const EMPTY_ANALYTICS: AnalyticsData = {
+  dailyActiveUsers: 0,
+  weeklyActiveUsers: 0,
+  monthlyActiveUsers: 0,
+  newSignUps: { daily: 0, total: 0 },
+  sessionCounts: { started: 0, completed: 0 },
+  topicBreakdown: [],
+  timeBucketUsage: [],
+  ctirToSefaria: 0,
+  retentionRates: { day1: 0, day7: 0, day30: 0 },
+  topRecommendedSources: [],
+  completionRates: 0,
+  avgResponseTime: 0,
+  errorRate: 0,
+  latencyStats: { p50: 0, p95: 0 },
+  deviceSplit: { ios: 0, android: 0, web: 0 },
+};
+
 interface TestResult {
   passed: boolean;
   responseTime: number;
@@ -58,7 +76,19 @@ export const AdminAnalyticsDashboard = () => {
       });
 
       if (error) throw error;
-      setAnalytics(data);
+      const mergedAnalytics: AnalyticsData = {
+        ...EMPTY_ANALYTICS,
+        ...(data || {}),
+        newSignUps: { ...EMPTY_ANALYTICS.newSignUps, ...(data?.newSignUps || {}) },
+        sessionCounts: { ...EMPTY_ANALYTICS.sessionCounts, ...(data?.sessionCounts || {}) },
+        topicBreakdown: data?.topicBreakdown ?? EMPTY_ANALYTICS.topicBreakdown,
+        timeBucketUsage: data?.timeBucketUsage ?? EMPTY_ANALYTICS.timeBucketUsage,
+        retentionRates: { ...EMPTY_ANALYTICS.retentionRates, ...(data?.retentionRates || {}) },
+        topRecommendedSources: data?.topRecommendedSources ?? EMPTY_ANALYTICS.topRecommendedSources,
+        latencyStats: { ...EMPTY_ANALYTICS.latencyStats, ...(data?.latencyStats || {}) },
+        deviceSplit: { ...EMPTY_ANALYTICS.deviceSplit, ...(data?.deviceSplit || {}) },
+      };
+      setAnalytics(mergedAnalytics);
     } catch (error) {
       console.error('Failed to fetch analytics:', error);
       toast({


### PR DESCRIPTION
## Summary
- prevent undefined analytic fields by merging fetched results with empty defaults

## Testing
- `npm test` *(fails: src/utils/commentarySelector.test.ts > commentarySelector > Spiritual Growth - Should be empty, src/utils/commentarySelector.test.ts > commentarySelector > Topic with "spiritual" - Should be empty, src/utils/commentarySelector.test.ts > commentarySelector > Unknown source type, src/utils/commentarySelector.test.ts > commentarySelector > Unclear source type)*
- `npm run lint` *(fails: supabase/functions/admin-stats/index.ts:29:40 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:64:30 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:79:30 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:130:35 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:131:35 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:132:35 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:141:40 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:182:31 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:195:42 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:202:41 @typescript-eslint/no-explicit-any, supabase/functions/admin-stats/index.ts:218:38 @typescript-eslint/no-explicit-any, supabase/functions/admin-test-runner/index.ts:21:21 @typescript-eslint/no-explicit-any, supabase/functions/admin-test-runner/index.ts:242:9 prefer-const)*

------
https://chatgpt.com/codex/tasks/task_b_6899cff653948326adb40e883b157c5a