### PR TITLE
Handle bullet source ranges and skip commentaries for spiritual growth

### DIFF
--- a/src/hooks/__tests__/useWebhookSource.test.tsx
+++ b/src/hooks/__tests__/useWebhookSource.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('react', () => ({
-  useState: (initial: any) => [initial, () => {}],
+  useState: (initial: unknown) => [initial, () => {}],
   useEffect: () => {},
-  useCallback: (fn: any) => fn,
+  useCallback: (fn: unknown) => fn,
 }));
 
 import { useWebhookSource } from '../useWebhookSource';
@@ -27,5 +27,23 @@ To: Genesis 1:2
     const parsed = parseWebhookResponse(sampleResponse, 'en');
     // Even with explicit From/To lines present, the original Source Range should be preserved
     expect(parsed.source_range).toBe('Genesis 1:1-2');
+  });
+
+  it('constructs range from explicit From/To lines when Source Range is absent', () => {
+    const { parseWebhookResponse } = useWebhookSource(5, 'topic', 'en');
+
+    const sampleResponse = `
+English: Sample Title
+- From: Genesis 1:1
+- To: Genesis 1:2
+
+**Brief Excerpt**: In the beginning...
+**Reflection Prompt**: What does this teach us?
+**Estimated Time**: 5
+**Sefaria**: https://www.sefaria.org/Genesis.1.1-2
+`;
+
+    const parsed = parseWebhookResponse(sampleResponse, 'en');
+    expect(parsed.source_range).toBe('Genesis 1:1 to Genesis 1:2');
   });
 });

--- a/src/hooks/useWebhookSource.tsx
+++ b/src/hooks/useWebhookSource.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import { useState, useEffect, useCallback } from 'react';
 import { selectCommentaries, shouldProvideCommentaries } from '@/utils/commentarySelector';
 
@@ -37,10 +38,10 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
       || responseText.match(/(?:^|\n)\s*(?:[*•\-]\s*)?(?:מקור הלימוד|טווח מקור|מראה מקום)\s*[:：\-–—]?\s*(?:\r?\n\s*)?([\s\S]*?)(?=(?:\n\s*)?(?:^|\n)\s*(?:\*\*|[*•\-]\s*)?(?:ציטוט קצר|קטע קצר|תמצית|ציטוט|שאלה|הרהור|זמן משוער|ספאריה|קישור|עברית|אנגלית|Brief\s+Excerpt|Excerpt|Summary|Key\s+Quote|Short\s+Quote|Quote|Reflection Prompt|Reflection Questions?|Estimated Time|Sefaria|Working Link|Hebrew|English)\b|$)/i);
 
     // Optional explicit From/To lines (English + Hebrew)
-    const fromEng = responseText.match(/(?:^|\n)\s*(?:\*\*)?\s*From\s*(?:\*\*)?\s*[:：\-–—]?\s*(.+?)(?:\n|$)/i)?.[1]?.trim();
-    const toEng = responseText.match(/(?:^|\n)\s*(?:\*\*)?\s*To\s*(?:\*\*)?\s*[:：\-–—]?\s*(.+?)(?:\n|$)/i)?.[1]?.trim();
-    const fromHeb = responseText.match(/(?:^|\n)\s*(?:\*\*)?\s*מ\s*(?:\*\*)?\s*[:：\-–—]?\s*(.+?)(?:\n|$)/)?.[1]?.trim();
-    const toHeb = responseText.match(/(?:^|\n)\s*(?:\*\*)?\s*עד\s*(?:\*\*)?\s*[:：\-–—]?\s*(.+?)(?:\n|$)/)?.[1]?.trim();
+    const fromEng = responseText.match(/(?:^|\n)\s*(?:[*•\-]+\s*)?(?:\*\*)?\s*From\s*(?:\*\*)?\s*[:：\-–—]?\s*(.+?)(?:\n|$)/i)?.[1]?.trim();
+    const toEng = responseText.match(/(?:^|\n)\s*(?:[*•\-]+\s*)?(?:\*\*)?\s*To\s*(?:\*\*)?\s*[:：\-–—]?\s*(.+?)(?:\n|$)/i)?.[1]?.trim();
+    const fromHeb = responseText.match(/(?:^|\n)\s*(?:[*•\-]+\s*)?(?:\*\*)?\s*מ\s*(?:\*\*)?\s*[:：\-–—]?\s*(.+?)(?:\n|$)/)?.[1]?.trim();
+    const toHeb = responseText.match(/(?:^|\n)\s*(?:[*•\-]+\s*)?(?:\*\*)?\s*עד\s*(?:\*\*)?\s*[:：\-–—]?\s*(.+?)(?:\n|$)/)?.[1]?.trim();
 
     // Excerpt (support bold and plain, flexible boundary to next heading)
     const excerptEngMatch = (
@@ -129,7 +130,7 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
 
     const sanitizeField = (raw: string) => {
       if (!raw) return '';
-      let s = raw
+      const s = raw
         // Strip Markdown links but keep the link text
         .replace(/\[([^\]]+)\]\((?:https?:\/\/)[^)]+\)/g, '$1')
         // Remove any bare URLs
@@ -161,7 +162,7 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
 
         // Remove any explicit From/To lines accidentally captured in the range block
         .split('\n')
-        .filter(line => !/^\s*(?:From|To|מ|עד)\s*[:：\-–—]?/i.test(line))
+        .filter(line => !/^\s*(?:[*•\-]+\s*)?(?:From|To|מ|עד)\s*[:：\-–—]?/i.test(line))
         .join('\n')
         .replace(/[ \t]+/g, ' ')
         .replace(/\r?\n+/g, ' ')
@@ -259,7 +260,7 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
       estimated_time: timeStr ? parseInt(timeStr) : timeSelected,
       sefaria_link: extractedLink,
     };
-  }, [timeSelected, topicSelected, language]);
+  }, [timeSelected, topicSelected]);
 
   const fetchWebhookSource = useCallback(async () => {
     setLoading(true);

--- a/src/utils/commentarySelector.ts
+++ b/src/utils/commentarySelector.ts
@@ -92,28 +92,19 @@ function identifySourceType(config: CommentaryConfig): keyof typeof COMMENTARY_M
  */
 export function selectCommentaries(config: CommentaryConfig): string[] {
   const normalizedTopic = (config.topicSelected || '').toLowerCase();
-  
-  // First, try to identify the source type from the content itself
-  const sourceType = identifySourceType(config);
-  
-  // Get commentaries based on detected source type, with topic-based fallbacks
-  let availableCommentaries: readonly string[] = [];
 
-  if (sourceType && COMMENTARY_MAPPINGS[sourceType]) {
-    availableCommentaries = COMMENTARY_MAPPINGS[sourceType];
-  } else {
-    // Fallback based on topic if source type can't be identified
-    if (normalizedTopic.includes('talmud')) {
-      availableCommentaries = COMMENTARY_MAPPINGS.talmud;
-    } else if (normalizedTopic.includes('halacha')) {
-      availableCommentaries = COMMENTARY_MAPPINGS.shulchan_aruch;
-    } else if (normalizedTopic.includes('tanach') || normalizedTopic.includes('tanakh')) {
-      availableCommentaries = COMMENTARY_MAPPINGS.tanach;
-    }
+  // Do not provide commentaries for Spiritual Growth topics
+  if (normalizedTopic.includes('spiritual')) {
+    return [];
   }
-  
-  // Return first 2 commentaries for consistency
-  return availableCommentaries.slice(0, 2);
+
+  // Only provide commentaries when the source type can be identified
+  const sourceType = identifySourceType(config);
+  if (!sourceType) {
+    return [];
+  }
+
+  return COMMENTARY_MAPPINGS[sourceType].slice(0, 2);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix webhook parsing to capture From/To ranges listed as bullets and build full source range
- Return commentaries only when source type is identified and topic isn't spiritual growth
- Add regression test for parsing From/To ranges without a Source Range heading

## Testing
- `npm test -- --run`
- `npx eslint src/hooks/useWebhookSource.tsx src/utils/commentarySelector.ts src/hooks/__tests__/useWebhookSource.test.tsx && echo 'Lint OK'`
- `npm run lint` *(fails: Unexpected any in supabase/functions and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6899dd4da700832699cffff5e10cf22e