### PR TITLE
Fix parsing of suggested source and range from webhook

### DIFF
--- a/src/hooks/__tests__/useWebhookSource.test.tsx
+++ b/src/hooks/__tests__/useWebhookSource.test.tsx
@@ -46,4 +46,38 @@ English: Sample Title
     const parsed = parseWebhookResponse(sampleResponse, 'en');
     expect(parsed.source_range).toBe('Genesis 1:1 to Genesis 1:2');
   });
+
+  it('parses suggested source and range lines', () => {
+    const { parseWebhookResponse } = useWebhookSource(5, 'topic', 'en');
+
+    const sampleResponse = `
+Suggested Source: Pirkei Avot 1:1
+Suggested Range: Pirkei Avot 1:1-2
+
+**Brief Excerpt**: Example...
+**Reflection Prompt**: Think about it
+**Estimated Time**: 5
+**Sefaria**: https://www.sefaria.org/Pirkei_Avot.1.1-2
+`;
+
+    const parsed = parseWebhookResponse(sampleResponse, 'en');
+    expect(parsed.title).toBe('Pirkei Avot 1:1');
+    expect(parsed.source_range).toBe('Pirkei Avot 1:1-2');
+  });
+
+  it('derives full range from sefaria link when range is missing', () => {
+    const { parseWebhookResponse } = useWebhookSource(5, 'topic', 'en');
+
+    const sampleResponse = `
+Suggested Source: Genesis 1
+
+**Brief Excerpt**: In the beginning...
+**Reflection Prompt**: What does this teach us?
+**Estimated Time**: 5
+**Sefaria**: https://www.sefaria.org/Genesis.1.1-2.3
+`;
+
+    const parsed = parseWebhookResponse(sampleResponse, 'en');
+    expect(parsed.source_range).toBe('Genesis 1:1-2:3');
+  });
 });

--- a/src/hooks/useWebhookSource.tsx
+++ b/src/hooks/useWebhookSource.tsx
@@ -28,10 +28,16 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
     const titleHebLabelMatch = responseText.match(/(?:^|\n)\s*Hebrew:\s*(.+?)(?:\n|$)/);
     const titleEngHeMatch = responseText.match(/(?:^|\n)\s*אנגלית\s*:\s*(.+?)(?:\n|$)/);
     const titleHebHeMatch = responseText.match(/(?:^|\n)\s*עברית\s*:\s*(.+?)(?:\n|$)/);
+    // Sometimes the webhook provides a single "Suggested Source" line
+    const suggestedSourceMatch = responseText.match(
+      /(?:^|\n)\s*(?:Suggested\s+Source|Source|Title)\s*[:：\-–—]?\s*(.+?)(?:\n|$)/i
+    );
 
     // Source range - improved to capture multi-line ranges completely
     const rangeEngMatch = responseText.match(/\*\*\s*Source Range\s*\*\*\s*[:：\-–—]?\s*(?:\r?\n\s*)?([\s\S]*?)(?=\n\s*\*\*|(?:\n\s*)?(?:^|\n)\s*(?:\*\*|[*•\-]\s*)?(?:Brief\s+Excerpt|Excerpt|Summary|Key\s+Quote|Short\s+Quote|Quote|Reflection Prompt|Reflection Questions?|Estimated Time|Sefaria|Working Link|Hebrew|English|ציטוט|תמצית|שאלה|הרהור|זמן משוער|ספאריה|קישור|עברית|אנגלית)\b|$)/i)
-      || responseText.match(/(?:^|\n)\s*(?:[*•\-]\s*)?Source Range\s*[:：\-–—]?\s*(?:\r?\n\s*)?([\s\S]*?)(?=(?:\n\s*)?(?:^|\n)\s*(?:\*\*|[*•\-]\s*)?(?:Brief\s+Excerpt|Excerpt|Summary|Key\s+Quote|Short\s+Quote|Quote|Reflection Prompt|Reflection Questions?|Estimated Time|Sefaria|Working Link|Hebrew|English|ציטוט|תמצית|שאלה|הרהור|זמן משוער|ספאריה|קישור|עברית|אנגלית)\b|$)/i);
+      || responseText.match(/(?:^|\n)\s*(?:[*•\-]\s*)?Source Range\s*[:：\-–—]?\s*(?:\r?\n\s*)?([\s\S]*?)(?=(?:\n\s*)?(?:^|\n)\s*(?:\*\*|[*•\-]\s*)?(?:Brief\s+Excerpt|Excerpt|Summary|Key\s+Quote|Short\s+Quote|Quote|Reflection Prompt|Reflection Questions?|Estimated Time|Sefaria|Working Link|Hebrew|English|ציטוט|תמצית|שאלה|הרהור|זמן משוער|ספאריה|קישור|עברית|אנגלית)\b|$)/i)
+      // Support newer "Suggested Range" or "Range" labels
+      || responseText.match(/(?:^|\n)\s*(?:Suggested\s+Range|Range)\s*[:：\-–—]?\s*(?:\r?\n\s*)?([\s\S]*?)(?=(?:\n\s*)?(?:^|\n)\s*(?:\*\*|[*•\-]\s*)?(?:Brief\s+Excerpt|Excerpt|Summary|Key\s+Quote|Short\s+Quote|Quote|Reflection Prompt|Reflection Questions?|Estimated Time|Sefaria|Working Link|Hebrew|English|ציטוט|תמצית|שאלה|הרהור|זמן משוער|ספאריה|קישור|עברית|אנגלית)\b|$)/i);
     
     // Hebrew source range - improved to capture complete multi-line descriptions
     const rangeHebMatch = responseText.match(/\*\*\s*(?:מקור הלימוד|טווח מקור|מראה מקום)\s*\*\*\s*[:：\-–—]?\s*(?:\r?\n\s*)?([\s\S]*?)(?=(?:\n\s*)?(?:^|\n)\s*(?:\*\*|[*•\-]\s*)?(?:ציטוט קצר|קטע קצר|תמצית|ציטוט|שאלה|הרהור|זמן משוער|ספאריה|קישור|עברית|אנגלית|Brief\s+Excerpt|Excerpt|Summary|Key\s+Quote|Short\s+Quote|Quote|Reflection Prompt|Reflection Questions?|Estimated Time|Sefaria|Working Link|Hebrew|English)\b|$)/i)
@@ -154,8 +160,9 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
           .replace(/^texts\//i, '')
           .replace(/^library\//i, '');
         const lastSeg = path.split('/').pop() || '';
-        const [bookPart, refPart] = lastSeg.split('.');
+        const [bookPart, ...refParts] = lastSeg.split('.');
         const book = bookPart.replace(/_/g, ' ').replace(/,/g, ', ').trim();
+        const refPart = refParts.join('.');
         if (!refPart) {
           return { book, range: book };
         }
@@ -166,8 +173,12 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
       }
     };
 
-    const englishTitleRaw = titleEngMatch?.[1] || titleEngHeMatch?.[1];
-    const hebrewTitleRaw = titleHebLabelMatch?.[1] || titleHebHeMatch?.[1];
+    let englishTitleRaw = titleEngMatch?.[1] || titleEngHeMatch?.[1];
+    let hebrewTitleRaw = titleHebLabelMatch?.[1] || titleHebHeMatch?.[1];
+
+    if (!englishTitleRaw && !hebrewTitleRaw && suggestedSourceMatch?.[1]) {
+      englishTitleRaw = suggestedSourceMatch[1];
+    }
 
     let sourceRange = (preferredLang === 'he'
       ? (rangeHebMatch?.[1] || rangeEngMatch?.[1])
@@ -210,6 +221,11 @@ export const useWebhookSource = (timeSelected: number, topicSelected: string, la
       const derived = deriveRangeFromLink(extractedLink);
       if (!finalRange) finalRange = derived.range;
       if (!baseTitle) baseTitle = derived.book || derived.range;
+    }
+
+    // If no explicit range but title looks like a range, use it
+    if (!finalRange && baseTitle && /\d/.test(baseTitle)) {
+      finalRange = baseTitle;
     }
 
     const title = baseTitle || finalRange || (preferredLang === 'he' ? 'מקור תורני' : 'Torah Source');

--- a/src/utils/commentarySelector.ts
+++ b/src/utils/commentarySelector.ts
@@ -100,7 +100,6 @@ function identifySourceType(config: CommentaryConfig): keyof typeof COMMENTARY_M
  * Selects 2 appropriate commentaries based on the topic selected
  */
 export function selectCommentaries(config: CommentaryConfig): string[] {
-
   // Do not provide commentaries for Spiritual Growth topics
   if (isSpiritualTopic(config.topicSelected)) {
     return [];
@@ -111,21 +110,6 @@ export function selectCommentaries(config: CommentaryConfig): string[] {
   if (!sourceType) {
     return [];
   }
-
-=======
-  const normalizedTopic = (config.topicSelected || '').toLowerCase();
-
-  // Do not provide commentaries for Spiritual Growth topics
-  if (normalizedTopic.includes('spiritual')) {
-    return [];
-  }
-
-  // Only provide commentaries when the source type can be identified
-  const sourceType = identifySourceType(config);
-  if (!sourceType) {
-    return [];
-  }
-
 
   return COMMENTARY_MAPPINGS[sourceType].slice(0, 2);
 }


### PR DESCRIPTION
## Summary
- Handle `Suggested Source` and `Suggested Range` lines when parsing webhook responses
- Fallback to title when range is missing to display study range
- Derive full range from Sefaria links when webhook omits explicit range
- Clean up merge conflict in commentary selector and add tests for new parsing

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_6899e3e46990832683d40675e547cbe1