### PR TITLE
Wrap SourceRecommendationV2 links in Button

### DIFF
--- a/src/components/SourceRecommendationV2.tsx
+++ b/src/components/SourceRecommendationV2.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Language } from "./LanguageToggle";
 import { useAuth } from "@/hooks/useAuth";
@@ -27,7 +27,6 @@ import { ScaleOnTap } from "@/components/ui/motion";
 import { useBlessingToast } from "@/components/ui/blessing-toast";
 import { ScrollIcon } from "@/components/ui/torah-icons";
 import { filterCommentariesByTopic } from "@/utils/commentarySelector";
-import { cn } from "@/lib/utils";
 
 interface SourceRecommendationProps {
   language: Language;
@@ -437,14 +436,21 @@ export const SourceRecommendationV2 = ({
                 )}
                 
                 {webhookSource.sefaria_link && isValidSefariaUrl(webhookSource.sefaria_link) && (
-                  <a
-                    className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'w-full touch-button inline-flex items-center justify-center')}
-                    href={normalizeSefariaUrl(webhookSource.sefaria_link)}
-                    target="_blank" rel="noopener noreferrer"
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    className="w-full touch-button inline-flex items-center justify-center"
                   >
-                    <ExternalLink className="h-4 w-4 mr-2 inline" />
-                    <span className="mobile-text-sm">{content[language].sefariaLink}</span>
-                  </a>
+                    <a
+                      href={normalizeSefariaUrl(webhookSource.sefaria_link)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLink className="h-4 w-4 mr-2 inline" />
+                      <span className="mobile-text-sm">{content[language].sefariaLink}</span>
+                    </a>
+                  </Button>
                 )}
               </div>
             </div>
@@ -493,14 +499,20 @@ export const SourceRecommendationV2 = ({
                   <span className="mobile-text-sm">{content[language].learnedButton}</span>
                 </Button>
                 
-                <a
-                  className={cn(buttonVariants({ variant: 'outline' }), 'touch-button sm:col-span-2 lg:col-span-1 inline-flex items-center justify-center')}
-                  href={getCalendarUrl()}
-                  target="_blank" rel="noopener noreferrer"
+                <Button
+                  asChild
+                  variant="outline"
+                  className="touch-button sm:col-span-2 lg:col-span-1 inline-flex items-center justify-center"
                 >
-                  <Calendar className="h-4 w-4 mr-2" />
-                  <span className="mobile-text-sm">{content[language].calendarButton}</span>
-                </a>
+                  <a
+                    href={getCalendarUrl()}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Calendar className="h-4 w-4 mr-2" />
+                    <span className="mobile-text-sm">{content[language].calendarButton}</span>
+                  </a>
+                </Button>
               </div>
 
               <Button


### PR DESCRIPTION
## Summary
- Wrap Sefaria link in `<Button asChild>` retaining external anchor attributes
- Wrap calendar link in `<Button asChild>` to rely on Button styling
- Remove manual `buttonVariants` usage

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_68a6e7cfd6748326b6be09fc4225eb91