### PR TITLE
Expand source range parsing with additional separators

### DIFF
--- a/src/components/SourceRecommendationV2.tsx
+++ b/src/components/SourceRecommendationV2.tsx
@@ -80,6 +80,35 @@ const content = {
   }
 };
 
+export const formatSourceRange = (
+  source: WebhookSource,
+  language: Language
+): string => {
+  // Use explicit start_ref and end_ref if available
+  if (source.start_ref && source.end_ref) {
+    return language === "he"
+      ? `${content[language].fromTo} ${source.start_ref} ${content[language].to} ${source.end_ref}`
+      : `${content[language].fromTo} ${source.start_ref} ${content[language].to} ${source.end_ref}`;
+  }
+
+  const range = source.source_range;
+  // Detect separators like "to", dashes, commas, or Hebrew "עד"
+  const separatorRegex = /\s+to\s+|\s+עד\s+|\s*[-–—,]\s*/i;
+  const hasRange = separatorRegex.test(range);
+
+  if (hasRange) {
+    const parts = range.split(separatorRegex);
+    if (parts.length >= 2) {
+      const [start, end] = parts.map((p) => p.trim());
+      return language === "he"
+        ? `${content[language].fromTo} ${start} ${content[language].to} ${end}`
+        : `${content[language].fromTo} ${start} ${content[language].to} ${end}`;
+    }
+  }
+
+  return range; // Return as-is if no range detected
+};
+
 export const SourceRecommendationV2 = ({ 
   language, 
   timeSelected, 
@@ -249,33 +278,6 @@ export const SourceRecommendationV2 = ({
       onReflection(currentSessionId);
     }
   };
-
-  const formatSourceRange = (source: WebhookSource, language: Language): string => {
-    // Use explicit start_ref and end_ref if available
-    if (source.start_ref && source.end_ref) {
-      return language === 'he'
-        ? `${content[language].fromTo} ${source.start_ref} ${content[language].to} ${source.end_ref}`
-        : `${content[language].fromTo} ${source.start_ref} ${content[language].to} ${source.end_ref}`;
-    }
-    
-    // Check if source_range contains "to", "-", or similar range indicators
-    const range = source.source_range;
-    const hasRange = /\s+to\s+|\s*-\s*|\s+עד\s+/.test(range);
-    
-    if (hasRange) {
-      // Extract start and end parts
-      const parts = range.split(/\s+to\s+|\s*-\s*|\s+עד\s+/i);
-      if (parts.length === 2) {
-        const [start, end] = parts.map(p => p.trim());
-        return language === 'he' 
-          ? `${content[language].fromTo} ${start} ${content[language].to} ${end}`
-          : `${content[language].fromTo} ${start} ${content[language].to} ${end}`;
-      }
-    }
-    
-    return range; // Return as-is if no range detected
-  };
-
   if (showLoading) {
     return (
       <SourceLoadingState

--- a/src/components/__tests__/formatSourceRange.test.ts
+++ b/src/components/__tests__/formatSourceRange.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { formatSourceRange } from '../SourceRecommendationV2';
+
+const baseSource = {
+  title: '',
+  title_he: '',
+  source_range: '',
+  excerpt: '',
+  commentaries: [] as string[],
+  reflection_prompt: '',
+  estimated_time: 0,
+  sefaria_link: ''
+};
+
+describe('formatSourceRange', () => {
+  const cases: [string, string][] = [
+    ['Genesis 1:1-1:3', 'From Genesis 1:1 to 1:3'],
+    ['Genesis 1:1 – 1:3', 'From Genesis 1:1 to 1:3'],
+    ['Genesis 1:1, 1:3', 'From Genesis 1:1 to 1:3'],
+    ['Genesis 1:1 to 1:3', 'From Genesis 1:1 to 1:3']
+  ];
+
+  cases.forEach(([range, expected]) => {
+    it(`formats "${range}" correctly`, () => {
+      const source = { ...baseSource, source_range: range } as any;
+      expect(formatSourceRange(source, 'en')).toBe(expected);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend `formatSourceRange` to detect "to", hyphens, en/em dashes, commas, and Hebrew "עד"
- expose and reuse `formatSourceRange` for cleaner formatting
- add unit tests exercising multiple range separators

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest --version` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68a6e7d240d08326b3c0be8a970df6a5