### PR TITLE
Add commentary fallback in recommendations

### DIFF
--- a/src/components/SourceRecommendationV2.tsx
+++ b/src/components/SourceRecommendationV2.tsx
@@ -26,7 +26,7 @@ import { MotionWrapper } from "@/components/MotionWrapper";
 import { ScaleOnTap } from "@/components/ui/motion";
 import { useBlessingToast } from "@/components/ui/blessing-toast";
 import { ScrollIcon } from "@/components/ui/torah-icons";
-import { filterCommentariesByTopic } from "@/utils/commentarySelector";
+import { filterCommentariesByTopic, selectCommentaries } from "@/utils/commentarySelector";
 import { cn } from "@/lib/utils";
 
 interface SourceRecommendationProps {
@@ -334,8 +334,18 @@ export const SourceRecommendationV2 = ({
   const excerpt = sanitizeText(webhookSource.excerpt);
   const reflectionPrompt = sanitizeText(webhookSource.reflection_prompt);
 
-  // Only use commentaries from webhook - no fallbacks
-  const rawCommentaries = webhookSource.commentaries || [];
+  // Prefer commentaries from webhook; otherwise derive them from source metadata
+  const rawCommentaries =
+    webhookSource.commentaries && webhookSource.commentaries.length > 0
+      ? webhookSource.commentaries
+      : selectCommentaries({
+          topicSelected,
+          sourceTitle: `${webhookSource.title} ${webhookSource.title_he || ''}`,
+          sourceRange:
+            webhookSource.source_range ||
+            `${webhookSource.start_ref || ''} ${webhookSource.end_ref || ''}`,
+          excerpt: webhookSource.excerpt || ''
+        });
   const filteredCommentaries = filterCommentariesByTopic(topicSelected, rawCommentaries);
   const displayedCommentaries = filteredCommentaries.slice(0, 2);
   
@@ -347,7 +357,8 @@ export const SourceRecommendationV2 = ({
   });
   
   console.debug('📚 Commentary display:', {
-    raw_from_webhook: rawCommentaries,
+    from_webhook: webhookSource.commentaries,
+    after_selection: rawCommentaries,
     after_topic_filter: filteredCommentaries,
     final_displayed: displayedCommentaries,
     topic_selected: topicSelected,


### PR DESCRIPTION
## Summary
- When webhook commentaries are empty, derive suggestions with `selectCommentaries`
- Filter and display commentaries so users always see relevant options

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_b_68a6e7d1ad6883269cb527a26fd961fc